### PR TITLE
[FIX] package-ecosystem dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates: 
-  - package-ecosystem: ""
+  - package-ecosystem: "yarn"
   directory: "/"
   schedule:
     interval: "daily"


### PR DESCRIPTION
# Feature

Change de package-ecosystem of the dependabot from `""` to `yarn`.

# Testing

Not applicable